### PR TITLE
ansible-ci-module の追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "gitsubmodule"
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    time: "02:00"
+    timezone: "Asia/Tokyo"
+  reviewers:
+    - "y-hashida"

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+      fail-fast: False
     steps:
       - name: Install LXD and CI tools
         run: |

--- a/.github/workflows/ansible-ci.yml
+++ b/.github/workflows/ansible-ci.yml
@@ -1,0 +1,59 @@
+name: ansible ci
+
+on:
+  push:
+    branches:
+      - "**"
+    tags:
+      - v*
+
+jobs:
+  create-matrix:
+    runs-on: ubuntu-20.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Install pip3 and tox
+        run: |
+          sudo apt update
+          sudo apt -y install python3 python3-pip python3-setuptools
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Create tox env list
+        id: set-matrix
+        run: |
+          TOX_ENV=$(python3 ansible-ci-module/scripts/toxenv_to_json.py)
+          echo "::set-output name=matrix::{\"tox_env\":[${TOX_ENV}]}"
+
+  ansible-ci:
+    needs: create-matrix
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix: ${{ fromJson(needs.create-matrix.outputs.matrix) }}
+    steps:
+      - name: Install LXD and CI tools
+        run: |
+          sudo apt update
+          sudo apt install lxd lxd-tools qemu-block-extra python3 python3-pip python3-setuptools
+
+      - name: Configure LXD
+        run: |
+          sudo lxd init --auto
+
+      - name: Install tox using python3-pip
+        run: |
+          sudo pip3 install tox
+
+      - uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: ansible-ci
+        run: |
+          sudo tox -e ${{ matrix.tox_env }} -c ansible-ci-module/tox.ini

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ansible-ci-module"]
+	path = ansible-ci-module
+	url = https://github.com/link-u/ansible-ci-module.git


### PR DESCRIPTION
### 変更点

* ansible-ci-module の追加
* このプルリクでできる CI について
  * ansible-lint による linting
  * molecule による各環境ごとのインストールテスト

* このプルリクではまだ未実装の CI について
  * testinfra による verify
    ※ これは別のプルリクで実装する予定.
